### PR TITLE
Update e2e02_train_test.ipynb

### DIFF
--- a/end2end/e2e02_train_test.ipynb
+++ b/end2end/e2e02_train_test.ipynb
@@ -28,7 +28,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Normalmente, se separa una parte de los datos para usarlos como conjunto de prueba (***train set***), y el se entrena el modelo con el resto (***training set***). Esto es para evitar el **sobreajuste** o ***overfitting***, dado cuando el modelo se ajusta demasiado a los datos de entrenamiento, y no generaliza bien a datos nuevos. Si el error en el conjunto de entrenamiento es bajo y en el de prueba es alto, es que el modelo está sobreajustado.\n",
+    "Normalmente, se separa una parte de los datos para usarlos como conjunto de prueba (***test set***), y se entrena el modelo con el resto (***train set***). Esto es para evitar el **sobreajuste** o ***overfitting***, dado cuando el modelo se ajusta demasiado a los datos de entrenamiento, y no generaliza bien a datos nuevos. Si el error en el conjunto de entrenamiento es bajo y en el de prueba es alto, es que el modelo está sobreajustado.\n",
     "\n",
     "Es habitual usar un 20% de los datos para el conjunto de prueba, pero esto depende del tamaño del dataset. Cuanto más grande sea el dataset, menos datos necesitaremos para el conjunto de prueba.\n",
     "<!-- TODO: En el original fuerza la semilla del random -->"


### PR DESCRIPTION
Se ha corregido una errata en esta línea, dónde se llama al conjunto de prueba "train set" y al conjunto de entrenamiento "training set":

"Normalmente, se separa una parte de los datos para usarlos como conjunto de prueba (train set), y el se entrena el modelo con el resto (training set)."

Y se ha sustituido por esta otra con los nombres corregidos:

Normalmente, se separa una parte de los datos para usarlos como conjunto de prueba (***test set***), y se entrena el modelo con el resto (***train set***).